### PR TITLE
feat: implement JWT authentication with Spring Security

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -44,6 +44,30 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId> <!-- Or jjwt-gson -->
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/github/junlianglu/backend/config/JwtConfig.java
+++ b/backend/src/main/java/com/github/junlianglu/backend/config/JwtConfig.java
@@ -1,0 +1,34 @@
+package com.github.junlianglu.backend.config;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+
+@Configuration
+public class JwtConfig {
+
+    @Value("${jwt.secret:default_secret_key}")
+    private String secret;
+
+    private final long expirationMs = 3600000; // 1 hour
+
+    public Key getSigningKey() {
+        byte[] keyBytes = Base64.getEncoder().encode(secret.getBytes());
+        return new SecretKeySpec(keyBytes, getAlgorithm().getJcaName());
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    public SignatureAlgorithm getAlgorithm() {
+        return SignatureAlgorithm.HS256;
+    }
+}

--- a/backend/src/main/java/com/github/junlianglu/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/github/junlianglu/backend/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.github.junlianglu.backend.config;
+
+
+import com.github.junlianglu.backend.security.JwtAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.context.annotation.Bean;
+
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/github/junlianglu/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/github/junlianglu/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.github.junlianglu.backend.security;
+
+import com.github.junlianglu.backend.config.JwtConfig;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtConfig jwtConfig;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("{\"error\":\"No token provided\"}");
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        try {
+            Claims claims = Jwts
+                    .parserBuilder()
+                    .setSigningKey(jwtConfig.getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            request.setAttribute("user", claims); // Attach decoded token info
+
+            filterChain.doFilter(request, response); // Pass to next filter
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("{\"error\":\"Invalid or expired token\"}");
+        }
+    }
+}


### PR DESCRIPTION
- Added JwtConfig.java to manage secret key and expiration logic
- Implemented JwtAuthenticationFilter to validate tokens on each request
- Configured SecurityConfig to integrate the JWT filter with Spring Security
- Restricted routes to authenticated users and allowed open access to auth endpoints
- Switched to parserBuilder() with proper key handling for token parsing