### PR TITLE
fix: enable lazy loading for DBRef fields to resolve deserialization …

### DIFF
--- a/backend/src/main/java/com/github/junlianglu/backend/model/User.java
+++ b/backend/src/main/java/com/github/junlianglu/backend/model/User.java
@@ -20,11 +20,11 @@ public class User {
     private Date createdAt = new Date();
     private Date updatedAt = new Date();
 
-//    @DBRef
-//    private List<Property> properties;
-//
-//    @DBRef
-//    private List<Booking> bookings;
+    @DBRef(lazy = true)
+    private List<Property> properties;
+
+    @DBRef(lazy = true)
+    private List<Booking> bookings;
 
     // Getters and setters
 
@@ -92,19 +92,19 @@ public class User {
         this.updatedAt = updatedAt;
     }
 
-//    public List<Property> getProperties() {
-//        return properties;
-//    }
-//
-//    public void setProperties(List<Property> properties) {
-//        this.properties = properties;
-//    }
-//
-//    public List<Booking> getBookings() {
-//        return bookings;
-//    }
-//
-//    public void setBookings(List<Booking> bookings) {
-//        this.bookings = bookings;
-//    }
+    public List<Property> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<Property> properties) {
+        this.properties = properties;
+    }
+
+    public List<Booking> getBookings() {
+        return bookings;
+    }
+
+    public void setBookings(List<Booking> bookings) {
+        this.bookings = bookings;
+    }
 }


### PR DESCRIPTION
…issue

- Added `lazy = true` to @DBRef annotations in User model for properties and bookings
- Prevented deserialization issues caused by unresolved or cyclic references
- Aligned Spring Boot reference handling with Mongoose-style lazy population
- Verified that users now load correctly without breaking the application